### PR TITLE
Update zeronode_install.sh

### DIFF
--- a/zeronode_install.sh
+++ b/zeronode_install.sh
@@ -16,7 +16,7 @@ COIN_PORT=23801
 RPC_PORT=23811
 OLDKEY=''
 
-NODEIP=$(curl -s4 icanhazip.com)
+NODEIP=$(curl -s https://api.ipify.org)
 
 BLUE="\033[0;34m"
 YELLOW="\033[0;33m"


### PR DESCRIPTION
Replaced 
  Line19: "NODEIP=$(curl -s4 icanhazip.com)"  - icanhazip.com ip service no longer working
with
  Line19:"NODEIP=$(curl -s4 https://api.ipify.org)" - Similar service to previous but functioning

Question: in the "-s" curl option what is the purpose of using "s4" vs "s"?  In my edit, I chose to use the "-s4" as opposed to the command as stated on the ipify.org documentation.